### PR TITLE
Set xterm-style mouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ All of the following are applied to the standard "Default Settings" PuTTY profil
 * Default font: Lucida Console, 12pt
 * Window size: 80x40
 * Font quality: ClearType
-* Action of mouse buttons: "Compromise", Middle Extends Right Pastes
+* Action of mouse buttons: XTerm, middle click pastes
 * Seconds between keepalives: 59
 * SSH: version 2 only
 * Hide mouse pointer when typing in window: On

--- a/putty-modern-256color.reg
+++ b/putty-modern-256color.reg
@@ -48,7 +48,7 @@ REGEDIT4
 "ANSIColour"=dword:00000001
 "Xterm256Colour"=dword:00000001
 "BoldAsColour"=dword:00000000
-"MouseIsXterm"=dword:00000000
+"MouseIsXterm"=dword:00000001
 "RectSelect"=dword:00000000
 "MouseOverride"=dword:00000001
 "LineCodePage"="UTF-8"


### PR DESCRIPTION
This is more familiar to users of Linux/Unix style terminals, and makes more sense for Windows users who want to open a menu on right click
